### PR TITLE
Could not match item when using import dependencies

### DIFF
--- a/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/AbstractOneToOneMatcher.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/AbstractOneToOneMatcher.java
@@ -37,11 +37,15 @@ public abstract class AbstractOneToOneMatcher<U, V> {
       }
 
       if (!itemMatched) {
-        throw new IllegalArgumentException("Could not match item " + subsetItem + " with superset");
+        handleUnmatchedItem(mapBuilder, subsetItem);
       }
     }
 
     return mapBuilder.build();
+  }
+
+  protected void handleUnmatchedItem(Builder<V,V> mapBuilder, V subsetItem) {
+    throw new IllegalArgumentException("Could not match item " + subsetItem + " with superset");
   }
 
   protected abstract V transform(U supersetItem);

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/DependencyMatcher.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/DependencyMatcher.java
@@ -1,13 +1,15 @@
 package com.github.ferstl.maven.pomenforcers.model.functions;
 
+import static com.github.ferstl.maven.pomenforcers.util.EnforcerRuleUtils.evaluateProperties;
+
 import java.util.Objects;
 
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Dependency;
 
 import com.github.ferstl.maven.pomenforcers.model.DependencyModel;
-
-import static com.github.ferstl.maven.pomenforcers.util.EnforcerRuleUtils.evaluateProperties;
+import com.github.ferstl.maven.pomenforcers.model.DependencyScope;
+import com.google.common.collect.ImmutableBiMap.Builder;
 
 /**
  * Matches Maven {@link Dependency} objects with {@link DependencyModel} objects.
@@ -42,4 +44,15 @@ public class DependencyMatcher extends AbstractOneToOneMatcher<Dependency, Depen
         && Objects.equals(supersetItem.getType(), type);
   }
 
+  @Override
+  protected void handleUnmatchedItem(
+      Builder<DependencyModel, DependencyModel> mapBuilder,
+      DependencyModel subsetItem) {
+    String type = evaluateProperties(subsetItem.getType(), getHelper());
+    if ("pom".equals(type) && DependencyScope.IMPORT.equals(subsetItem.getScope())) {
+      mapBuilder.put(subsetItem, subsetItem);
+    } else {
+      super.handleUnmatchedItem(mapBuilder, subsetItem);
+    }
+  }
 }


### PR DESCRIPTION
import dependencies are not part of the resolved maven dependecies, only of the declaration, which triggers a "Could not match item" exception when using DependencyManagementOrder. This fix prevents the exception, and adds the original import dependency to the resolved dependencies, to make sure it is included in the ordering process.
