### PR TITLE
#25 Handle default groupId "org.apache.maven.plugins" for plugins

### DIFF
--- a/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/PluginMatcher.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/model/functions/PluginMatcher.java
@@ -16,18 +16,18 @@
 package com.github.ferstl.maven.pomenforcers.model.functions;
 
 import java.util.Objects;
-
 import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
 import org.apache.maven.model.Plugin;
-
 import com.github.ferstl.maven.pomenforcers.model.PluginModel;
-
 import static com.github.ferstl.maven.pomenforcers.util.EnforcerRuleUtils.evaluateProperties;
+import static com.google.common.base.Strings.isNullOrEmpty;
 
 /**
  * Matches Maven {@link Plugin} objects with {@link PluginModel} objects.
  */
 public class PluginMatcher extends AbstractOneToOneMatcher<Plugin, PluginModel> {
+
+  private static final String DEFAULT_GROUP_ID = "org.apache.maven.plugins";
 
   public PluginMatcher(EnforcerRuleHelper helper) {
     super(helper);
@@ -40,11 +40,16 @@ public class PluginMatcher extends AbstractOneToOneMatcher<Plugin, PluginModel> 
 
   @Override
   protected boolean matches(PluginModel supersetItem, PluginModel subsetItem) {
-    String groupId = evaluateProperties(subsetItem.getGroupId(), getHelper());
+    String groupId = getGroupId(subsetItem);
     String artifactId = evaluateProperties(subsetItem.getArtifactId(), getHelper());
 
     return Objects.equals(supersetItem.getGroupId(), groupId)
         && Objects.equals(supersetItem.getArtifactId(), artifactId);
+  }
+
+  private String getGroupId(PluginModel plugin) {
+    String groupId = evaluateProperties(plugin.getGroupId(), getHelper());
+    return !isNullOrEmpty(groupId) ? groupId : DEFAULT_GROUP_ID;
   }
 
 }

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/model/functions/PluginMatcherTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/model/functions/PluginMatcherTest.java
@@ -1,0 +1,61 @@
+package com.github.ferstl.maven.pomenforcers.model.functions;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.model.Plugin;
+import org.junit.Before;
+import org.junit.Test;
+import com.github.ferstl.maven.pomenforcers.model.PluginModel;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class PluginMatcherTest {
+
+  private PluginMatcher pluginMatcher;
+
+  @Before
+  public void before() {
+    this.pluginMatcher = new PluginMatcher(mock(EnforcerRuleHelper.class));
+  }
+
+  @Test
+  public void transform() {
+    // arrange
+    Plugin plugin = new Plugin();
+    plugin.setGroupId("a");
+    plugin.setArtifactId("b");
+    plugin.setVersion("c");
+
+    // act
+    PluginModel pluginModel = this.pluginMatcher.transform(plugin);
+
+    // assert
+    assertEquals("a", pluginModel.getGroupId());
+    assertEquals("b", pluginModel.getArtifactId());
+    assertEquals("c", pluginModel.getVersion());
+  }
+
+  @Test
+  public void matchWithAllGavParameters() {
+    PluginModel supersetPlugin = new PluginModel("a", "b", "c");
+    PluginModel subsetPlugin = new PluginModel("a", "b", "c");
+
+    assertTrue(this.pluginMatcher.matches(supersetPlugin, subsetPlugin));
+  }
+
+  @Test
+  public void matchWithDefaultGroupIdForNull() {
+    PluginModel supersetPlugin = new PluginModel("org.apache.maven.plugins", "b", "c");
+    PluginModel subsetPlugin = new PluginModel(null, "b", "c");
+
+    assertTrue(this.pluginMatcher.matches(supersetPlugin, subsetPlugin));
+  }
+
+  @Test
+  public void matchWithDefaultGroupIdForEmpty() {
+    PluginModel supersetPlugin = new PluginModel("org.apache.maven.plugins", "b", "c");
+    PluginModel subsetPlugin = new PluginModel("", "b", "c");
+
+    assertTrue(this.pluginMatcher.matches(supersetPlugin, subsetPlugin));
+  }
+}

--- a/src/test/projects/example-project/pom.xml
+++ b/src/test/projects/example-project/pom.xml
@@ -86,7 +86,7 @@
     <pluginManagement>
       <plugins>
         <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
+          <!-- intentionally no groupId -->
           <artifactId>maven-compiler-plugin</artifactId>
           <version>2.3.2</version>
           <configuration>


### PR DESCRIPTION
Plugins may omit the groupId in case it is "org.apache.maven.plugins".