### PR TITLE
#27 Place "import" scoped dependencies at the beginning of dependencyManagement

### DIFF
--- a/src/main/java/com/github/ferstl/maven/pomenforcers/AbstractPedanticDependencyOrderEnforcer.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/AbstractPedanticDependencyOrderEnforcer.java
@@ -16,12 +16,14 @@
 package com.github.ferstl.maven.pomenforcers;
 
 import java.util.Collection;
+import java.util.EnumSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.project.MavenProject;
 import com.github.ferstl.maven.pomenforcers.model.DependencyElement;
 import com.github.ferstl.maven.pomenforcers.model.DependencyModel;
+import com.github.ferstl.maven.pomenforcers.model.DependencyScope;
 import com.github.ferstl.maven.pomenforcers.model.functions.DependencyMatcher;
 import com.github.ferstl.maven.pomenforcers.priority.CompoundPriorityOrdering;
 import com.github.ferstl.maven.pomenforcers.util.CommaSeparatorUtils;
@@ -31,6 +33,7 @@ import com.google.common.collect.Sets;
 import static com.github.ferstl.maven.pomenforcers.model.DependencyElement.ARTIFACT_ID;
 import static com.github.ferstl.maven.pomenforcers.model.DependencyElement.GROUP_ID;
 import static com.github.ferstl.maven.pomenforcers.model.DependencyElement.SCOPE;
+import static java.util.stream.Collectors.toList;
 
 
 abstract class AbstractPedanticDependencyOrderEnforcer extends AbstractPedanticEnforcer {
@@ -39,6 +42,11 @@ abstract class AbstractPedanticDependencyOrderEnforcer extends AbstractPedanticE
 
   public AbstractPedanticDependencyOrderEnforcer() {
     this.artifactOrdering = CompoundPriorityOrdering.orderBy(SCOPE, GROUP_ID, ARTIFACT_ID);
+    Iterable<String> scopePriorities = EnumSet.allOf(DependencyScope.class)
+        .stream()
+        .map(DependencyScope::getScopeName)
+        .collect(toList());
+    this.artifactOrdering.setPriorities(SCOPE, scopePriorities);
   }
 
   /**

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/model/DependencyScope.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/model/DependencyScope.java
@@ -21,12 +21,12 @@ import static java.util.Objects.requireNonNull;
 
 public enum DependencyScope {
 
+  IMPORT("import"),
   COMPILE("compile"),
   PROVIDED("provided"),
   RUNTIME("runtime"),
-  TEST("test"),
   SYSTEM("system"),
-  IMPORT("import");
+  TEST("test");
 
   private static final Map<String, DependencyScope> dependencyScopeMap;
 

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/priority/CompoundPriorityOrdering.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/priority/CompoundPriorityOrdering.java
@@ -61,6 +61,7 @@ public class CompoundPriorityOrdering<T, P extends Comparable<P>, F extends Prio
   }
 
   public void setPriorities(F artifactElement, Iterable<P> priorities) {
+    this.priorityMap.removeAll(artifactElement);
     this.priorityMap.putAll(artifactElement, priorities);
   }
 

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/AbstractPedanticDependencyOrderEnforcerTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/AbstractPedanticDependencyOrderEnforcerTest.java
@@ -41,11 +41,11 @@ public abstract class AbstractPedanticDependencyOrderEnforcerTest<T extends Abst
 
   @Test
   public void defaultSettingsCorrect() {
-    this.dependencyAdder.addDependency("a.b.c", "a", DependencyScope.COMPILE);
-    this.dependencyAdder.addDependency("a.b.c", "b", DependencyScope.COMPILE);
-
     this.dependencyAdder.addDependency("d.e.f", "a", DependencyScope.IMPORT);
     this.dependencyAdder.addDependency("d.e.f", "b", DependencyScope.IMPORT);
+
+    this.dependencyAdder.addDependency("a.b.c", "a", DependencyScope.COMPILE);
+    this.dependencyAdder.addDependency("a.b.c", "b", DependencyScope.COMPILE);
 
     this.dependencyAdder.addDependency("g.h.i", "a", DependencyScope.PROVIDED);
     this.dependencyAdder.addDependency("g.h.i", "b", DependencyScope.PROVIDED);


### PR DESCRIPTION
The new default scope order is:
- import
- compile
- provided
- runtime
- system
- test