### PR TITLE
Trim whitespace from comma separated values.

### DIFF
--- a/src/main/java/com/github/ferstl/maven/pomenforcers/util/CommaSeparatorUtils.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/util/CommaSeparatorUtils.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.toCollection;
 
 public final class CommaSeparatorUtils {
 
-  private static final Splitter COMMA_SPLITTER = Splitter.on(",");
+  private static final Splitter COMMA_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings();
 
   public static void splitAndAddToCollection(String commaSeparatedItems, Collection<String> collection) {
     splitAndAddToCollection(commaSeparatedItems, collection, Function.identity());

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/util/CommaSeparatorUtilsTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/util/CommaSeparatorUtilsTest.java
@@ -1,0 +1,28 @@
+package com.github.ferstl.maven.pomenforcers.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+public class CommaSeparatorUtilsTest {
+    @Test
+    public void testSplitAndAddToCollection() {
+        final Map<String, List<String>> tests = ImmutableMap.<String, List<String>> builder()
+            .put("a,b,c", ImmutableList.of("a", "b", "c"))
+            .put("a,b,,,c,", ImmutableList.of("a", "b", "c"))
+            .put(" a \n,\n   \t b   ,\r\n  c \t\n", ImmutableList.of("a", "b", "c"))
+            .build();
+        for (Map.Entry<String, List<String>> test : tests.entrySet()) {
+            final List<String> l = new ArrayList<>();
+            CommaSeparatorUtils.splitAndAddToCollection(test.getKey(), l);
+            assertThat(l, equalTo(test.getValue()));
+        }
+    }
+}


### PR DESCRIPTION
Update CommaSeparatorUtils to use `trimResults` and `omitEmptyStrings`
to allow comma separated values to include whitespace and allow breaking
up very long configuration element values.

Fixes #35.