### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,7 @@
       <artifactId>diffutils</artifactId>
       <version>1.3.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.glassfish.jaxb</groupId>
-      <artifactId>jaxb-runtime</artifactId>
-      <version>2.3.1</version>
-    </dependency>
+    
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
@@ -136,13 +132,7 @@
       </exclusions>
     </dependency>
 
-    <dependency>
-      <groupId>io.takari.maven.plugins</groupId>
-      <artifactId>takari-plugin-integration-testing</artifactId>
-      <version>2.9.2</version>
-      <type>pom</type>
-      <scope>test</scope>
-    </dependency>
+    
 
     <dependency>
       <groupId>io.takari.maven.plugins</groupId>
@@ -311,7 +301,7 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
-        </plugin>
+        <configuration><parallel>all</parallel></configuration></plugin>
 
         <plugin>
           <groupId>org.eluder.coveralls</groupId>


### PR DESCRIPTION

[Apache Maven Dependency Plugin](https://maven.apache.org/plugins/maven-dependency-plugin/index.html) can be used to find unused dependencies. And I found following list. Maybe we can remove them.
pedantic-pom-enforcers
{groupId='org.glassfish.jaxb', artifactId='jaxb-runtime', version='2.3.1', scope='compile'}
{groupId='io.takari.maven.plugins', artifactId='takari-plugin-integration-testing', version='2.9.2', scope='test'}


According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
