### PR TITLE
Allow custom properties for the allowUnmanagedProjectVersions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If so, the *Pedantic POM Enforcers* are absolutely the thing you need!
 
 
 ### What are the Pedantic POM Enforcers?
-The *Pedantic POM Enforcers* consist of serveral Maven enforcer rules that help you keep your project setup consistent and organized. For example, the enforcer rules ensure that your POM files are organized in a well-defined manner, that your `<modules>`/`<dependencyManagement>`/`<dependencies>`/`<pluginManagement>` sections are sorted in a reasonable way and that version numbers, plugin configurations, etc. are defined only on places where it makes sense.
+The *Pedantic POM Enforcers* consist of several Maven enforcer rules that help you keep your project setup consistent and organized. For example, the enforcer rules ensure that your POM files are organized in a well-defined manner, that your `<modules>`/`<dependencyManagement>`/`<dependencies>`/`<pluginManagement>` sections are sorted in a reasonable way and that version numbers, plugin configurations, etc. are defined only in places where it makes sense.
 
 
 ### Release Notes / Solved Issues
@@ -26,7 +26,7 @@ The *Pedantic POM Enforcers* consist of serveral Maven enforcer rules that help 
 ### How to use the Pedantic POM Enforcers
 The *Pedantic POM Enforcers* are available on [Maven Central](https://repo1.maven.org/maven2/com/github/ferstl/pedantic-pom-enforcers/). So no further repository configuration is required.
 
-To activate the enforcer rules, just declare them in the configuration of the [`maven-enforcer-plugin`](http://maven.apache.org/enforcer/maven-enforcer-plugin/). The simplest way of doing this is using the [`CompoundPedanticEnforcer`](https://github.com/ferstl/pedantic-pom-enforcers/wiki/CompoundPedanticEnforcer), which is able to aggregate all choosen enforcer rules. The compound enforcer is also more efficient than using the single enforcer rules separately.
+To activate the enforcer rules, just declare them in the configuration of the [`maven-enforcer-plugin`](http://maven.apache.org/enforcer/maven-enforcer-plugin/). The simplest way of doing this is using the [`CompoundPedanticEnforcer`](https://github.com/ferstl/pedantic-pom-enforcers/wiki/CompoundPedanticEnforcer), which is able to aggregate all chosen enforcer rules. The compound enforcer is also more efficient than using the single enforcer rules separately.
 
     <build>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   <packaging>jar</packaging>
   <name>Pedantic POM Enforcers</name>
   <description>
-    The Pedantic POM Enforcers consist of serveral Maven enforcer rules that help you keep your
+    The Pedantic POM Enforcers consist of several Maven enforcer rules that help you keep your
     project setup consistent and organized.
   </description>
   <url>https://github.com/ferstl/pedantic-pom-enforcers</url>

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/CompoundPedanticEnforcer.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/CompoundPedanticEnforcer.java
@@ -48,7 +48,8 @@ import com.google.common.collect.Sets;
  *         &lt;dependencyManagementArtifactIdPriorities&gt;commons-,utils-&lt;/dependencyManagementArtifactIdPriorities&gt;
  *         &lt;!-- DEPENDENCY_CONFIGURATION configuration --&gt;
  *         &lt;manageDependencyVersions&gt;true&lt;/manageDependencyVersions&gt;
- *         &lt;allowDependencyUnmangedProjectVersions&gt;true&lt;/allowDependencyUnmangedProjectVersions&gt;
+ *         &lt;allowDependencyUnmanagedProjectVersions&gt;true&lt;/allowDependencyUnmanagedProjectVersions&gt;
+ *         &lt;allowedDependencyUnmanagedProjectVersionProps&gt;version,project.version&lt;/allowedDependencyUnmanagedProjectVersionProps&gt;
  *         &lt;manageDependencyExclusions&gt;true&lt;/manageDependencyExclusions&gt;
  *         &lt;!-- DEPENDENCY_ELEMENT configuration --&gt;
  *         &lt;dependencyElementOrdering&gt;true&lt;/dependencyElementOrdering&gt;
@@ -70,7 +71,8 @@ import com.google.common.collect.Sets;
  *         &lt;pluginManagementArtifactIdPriorities&gt;mytest-,myintegrationtest-&lt;/pluginManagementArtifactIdPriorities&gt;
  *         &lt;!-- PLUGIN_CONFIGURATION configuration --&gt;
  *         &lt;managePluginVersions&gt;true&lt;/managePluginVersions&gt;
- *         &lt;allowPluginUnmangedProjectVersions&gt;true&lt;/allowPluginUnmangedProjectVersions&gt;
+ *         &lt;allowPluginUnmanagedProjectVersions&gt;true&lt;/allowPluginUnmanagedProjectVersions&gt;
+ *         &lt;allowedPluginUnmanagedProjectVersionProps&gt;version,project.version&lt;/allowedPluginUnmanagedProjectVersionProps&gt;
  *         &lt;managePluginConfigurations&gt;true&lt;/managePluginConfigurations&gt;
  *         &lt;managePluginDependencies&gt;true&lt;/managePluginDependencies&gt;
  *         &lt;!-- PLUGIN_ELEMENT configuration --&gt;
@@ -218,7 +220,16 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
    * @configParam
    * @since 2.2.0
    */
-  private Boolean allowDependencyUnmangedProjectVersions;
+  private Boolean allowDependencyUnmanagedProjectVersions;
+
+  /**
+   * See
+   * {@link PedanticDependencyConfigurationEnforcer#setAllowedUnmanagedProjectVersionProps(String)}.
+   *
+   * @configParam
+   * @since 2.2.0
+   */
+  private String allowedDependencyUnmanagedProjectVersionProps;
 
   /**
    * See
@@ -335,7 +346,16 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
    * @configParam
    * @since 2.2.0
    */
-  private Boolean allowPluginUnmangedProjectVersions;
+  private Boolean allowPluginUnmanagedProjectVersions;
+
+  /**
+   * See
+   * {@link PedanticPluginConfigurationEnforcer#setAllowedUnmanagedProjectVersionProps(String)}.
+   *
+   * @configParam
+   * @since 2.2.0
+   */
+  private String allowedPluginUnmanagedProjectVersionProps;
 
   /**
    * See {@link PedanticPluginConfigurationEnforcer#setManageConfigurations(boolean)}
@@ -527,8 +547,11 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
       if (CompoundPedanticEnforcer.this.allowUnmangedProjectVersions != null) { // deprecated but kept for compatibility
         dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowUnmangedProjectVersions);
       }
-      if (CompoundPedanticEnforcer.this.allowDependencyUnmangedProjectVersions != null) {
-        dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowDependencyUnmangedProjectVersions);
+      if (CompoundPedanticEnforcer.this.allowDependencyUnmanagedProjectVersions != null) {
+        dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowDependencyUnmanagedProjectVersions);
+      }
+      if (!Strings.isNullOrEmpty(CompoundPedanticEnforcer.this.allowedDependencyUnmanagedProjectVersionProps)) {
+        dependencyConfigurationEnforcer.setAllowedUnmanagedProjectVersionProps(CompoundPedanticEnforcer.this.allowedDependencyUnmanagedProjectVersionProps);
       }
       if (CompoundPedanticEnforcer.this.manageDependencyExclusions != null) {
         dependencyConfigurationEnforcer.setManageExclusions(CompoundPedanticEnforcer.this.manageDependencyExclusions);
@@ -575,8 +598,11 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
       if (CompoundPedanticEnforcer.this.managePluginVersions != null) {
         enforcer.setManageVersions(CompoundPedanticEnforcer.this.managePluginVersions);
       }
-      if (CompoundPedanticEnforcer.this.allowPluginUnmangedProjectVersions != null) {
-        enforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowPluginUnmangedProjectVersions);
+      if (CompoundPedanticEnforcer.this.allowPluginUnmanagedProjectVersions != null) {
+        enforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowPluginUnmanagedProjectVersions);
+      }
+      if (!Strings.isNullOrEmpty(CompoundPedanticEnforcer.this.allowedPluginUnmanagedProjectVersionProps)) {
+        enforcer.setAllowedUnmanagedProjectVersionProps(CompoundPedanticEnforcer.this.allowedPluginUnmanagedProjectVersionProps);
       }
       if (CompoundPedanticEnforcer.this.managePluginConfigurations != null) {
         enforcer.setManageConfigurations(CompoundPedanticEnforcer.this.managePluginConfigurations);

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/CompoundPedanticEnforcer.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/CompoundPedanticEnforcer.java
@@ -48,7 +48,7 @@ import com.google.common.collect.Sets;
  *         &lt;dependencyManagementArtifactIdPriorities&gt;commons-,utils-&lt;/dependencyManagementArtifactIdPriorities&gt;
  *         &lt;!-- DEPENDENCY_CONFIGURATION configuration --&gt;
  *         &lt;manageDependencyVersions&gt;true&lt;/manageDependencyVersions&gt;
- *         &lt;allowUnmangedProjectVersions&gt;true&lt;/allowUnmangedProjectVersions&gt;
+ *         &lt;allowDependencyUnmangedProjectVersions&gt;true&lt;/allowDependencyUnmangedProjectVersions&gt;
  *         &lt;manageDependencyExclusions&gt;true&lt;/manageDependencyExclusions&gt;
  *         &lt;!-- DEPENDENCY_ELEMENT configuration --&gt;
  *         &lt;dependencyElementOrdering&gt;true&lt;/dependencyElementOrdering&gt;
@@ -70,6 +70,7 @@ import com.google.common.collect.Sets;
  *         &lt;pluginManagementArtifactIdPriorities&gt;mytest-,myintegrationtest-&lt;/pluginManagementArtifactIdPriorities&gt;
  *         &lt;!-- PLUGIN_CONFIGURATION configuration --&gt;
  *         &lt;managePluginVersions&gt;true&lt;/managePluginVersions&gt;
+ *         &lt;allowPluginUnmangedProjectVersions&gt;true&lt;/allowPluginUnmangedProjectVersions&gt;
  *         &lt;managePluginConfigurations&gt;true&lt;/managePluginConfigurations&gt;
  *         &lt;managePluginDependencies&gt;true&lt;/managePluginDependencies&gt;
  *         &lt;!-- PLUGIN_ELEMENT configuration --&gt;
@@ -81,7 +82,7 @@ import com.google.common.collect.Sets;
  *         &lt;pluginManagingPoms&gt;com.myproject:parent-pom&lt;/pluginManagingPoms&gt;
  *         &lt;!-- DEPENDENCY_ELEMENT --&gt;
  *         &lt;dependencyElementOrdering&gt;groupId,artifactid,version&lt;/dependencyElementOrdering&gt;
- *         &lt;checkDependencyElements&gt;true&lt;/heckDependencyElements&gt;
+ *         &lt;checkDependencyElements&gt;true&lt;/checkDependencyElements&gt;
  *         &lt;checkDependencyManagementElements&gt;true&lt;/checkDependencyManagementElements&gt;
  *       &lt;/compound&gt;
  *     &lt;/rules&gt;
@@ -206,8 +207,18 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
    *
    * @configParam
    * @since 1.0.0
+   * @deprecated 2.2.0
    */
   private Boolean allowUnmangedProjectVersions;
+
+  /**
+   * See
+   * {@link PedanticDependencyConfigurationEnforcer#setAllowUnmanagedProjectVersions(boolean)}.
+   *
+   * @configParam
+   * @since 2.2.0
+   */
+  private Boolean allowDependencyUnmangedProjectVersions;
 
   /**
    * See
@@ -311,7 +322,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private String pluginManagingPoms;
 
   /**
-   * See {@link PedanticPluginConfigurationEnforcer#managePluginVersions}.
+   * See {@link PedanticPluginConfigurationEnforcer#setManageVersions(boolean)}.
    *
    * @configParam
    * @since 1.0.0
@@ -319,7 +330,15 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private Boolean managePluginVersions;
 
   /**
-   * See {@link PedanticPluginConfigurationEnforcer#managePluginConfigurations}
+   * See {@link PedanticPluginConfigurationEnforcer#setAllowUnmanagedProjectVersions(boolean)}.
+   *
+   * @configParam
+   * @since 2.2.0
+   */
+  private Boolean allowPluginUnmangedProjectVersions;
+
+  /**
+   * See {@link PedanticPluginConfigurationEnforcer#setManageConfigurations(boolean)}
    *
    * @configParam
    * @since 1.0.0
@@ -327,7 +346,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private Boolean managePluginConfigurations;
 
   /**
-   * See {@link PedanticPluginConfigurationEnforcer#managePluginDependencies}
+   * See {@link PedanticPluginConfigurationEnforcer#setManageDependencies(boolean)}
    *
    * @configParam
    * @since 1.0.0
@@ -335,7 +354,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private Boolean managePluginDependencies;
 
   /**
-   * See {@link PedanticDependencyElementEnforcer#elementOrdering}.
+   * See {@link PedanticDependencyElementEnforcer#setElementPriorities(String)}.
    *
    * @configParam
    * @since 2.0.0
@@ -343,7 +362,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private String dependencyElementOrdering;
 
   /**
-   * See {@link PedanticDependencyElementEnforcer#checkDependencies}.
+   * See {@link PedanticDependencyElementEnforcer#setCheckDependencies(boolean)}.
    *
    * @configParam
    * @since 2.0.0
@@ -351,7 +370,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private Boolean checkDependencyElements;
 
   /**
-   * See {@link PedanticDependencyElementEnforcer#checkDependencyManagement}.
+   * See {@link PedanticDependencyElementEnforcer#setCheckDependencyManagement(boolean)}.
    *
    * @configParam
    * @since 2.0.0
@@ -360,7 +379,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
 
 
   /**
-   * See {@link PedanticPluginElementEnforcer#elementOrdering}.
+   * See {@link PedanticPluginElementEnforcer#setElementPriorities(String)}.
    *
    * @configParam
    * @since 2.0.0
@@ -369,7 +388,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
 
 
   /**
-   * See {@link PedanticPluginElementEnforcer#checkPlugins}.
+   * See {@link PedanticPluginElementEnforcer#setCheckPlugins(boolean)}.
    *
    * @configParam
    * @since 2.0.0
@@ -377,7 +396,7 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
   private Boolean checkPluginElements;
 
   /**
-   * See {@link PedanticPluginElementEnforcer#checkPluginManagement}.
+   * See {@link PedanticPluginElementEnforcer#setCheckPluginManagement(boolean)}.
    *
    * @configParam
    * @since 2.0.0
@@ -505,9 +524,11 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
       if (CompoundPedanticEnforcer.this.manageDependencyVersions != null) {
         dependencyConfigurationEnforcer.setManageVersions(CompoundPedanticEnforcer.this.manageDependencyVersions);
       }
-      if (CompoundPedanticEnforcer.this.allowUnmangedProjectVersions != null) {
-        dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(
-            CompoundPedanticEnforcer.this.allowUnmangedProjectVersions);
+      if (CompoundPedanticEnforcer.this.allowUnmangedProjectVersions != null) { // deprecated but kept for compatibility
+        dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowUnmangedProjectVersions);
+      }
+      if (CompoundPedanticEnforcer.this.allowDependencyUnmangedProjectVersions != null) {
+        dependencyConfigurationEnforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowDependencyUnmangedProjectVersions);
       }
       if (CompoundPedanticEnforcer.this.manageDependencyExclusions != null) {
         dependencyConfigurationEnforcer.setManageExclusions(CompoundPedanticEnforcer.this.manageDependencyExclusions);
@@ -553,6 +574,9 @@ public class CompoundPedanticEnforcer extends AbstractPedanticEnforcer {
     public void visit(PedanticPluginConfigurationEnforcer enforcer) {
       if (CompoundPedanticEnforcer.this.managePluginVersions != null) {
         enforcer.setManageVersions(CompoundPedanticEnforcer.this.managePluginVersions);
+      }
+      if (CompoundPedanticEnforcer.this.allowPluginUnmangedProjectVersions != null) {
+        enforcer.setAllowUnmanagedProjectVersions(CompoundPedanticEnforcer.this.allowPluginUnmangedProjectVersions);
       }
       if (CompoundPedanticEnforcer.this.managePluginConfigurations != null) {
         enforcer.setManageConfigurations(CompoundPedanticEnforcer.this.managePluginConfigurations);

--- a/src/main/java/com/github/ferstl/maven/pomenforcers/PedanticDependencyConfigurationEnforcer.java
+++ b/src/main/java/com/github/ferstl/maven/pomenforcers/PedanticDependencyConfigurationEnforcer.java
@@ -15,11 +15,15 @@
  */
 package com.github.ferstl.maven.pomenforcers;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import com.github.ferstl.maven.pomenforcers.model.DependencyModel;
+import com.github.ferstl.maven.pomenforcers.util.CommaSeparatorUtils;
 import static com.github.ferstl.maven.pomenforcers.ErrorReport.toList;
 
 /**
@@ -31,8 +35,10 @@ import static com.github.ferstl.maven.pomenforcers.ErrorReport.toList;
  *       &lt;dependencConfiguration implementation=&quot;com.github.ferstl.maven.pomenforcers.PedanticDependencyConfigurationEnforcer&quot;&gt;
  *         &lt;!-- Manage dependency versions in dependency management --&gt;
  *         &lt;manageVersions&gt;true&lt;/manageVersions&gt;
- *         &lt;!-- allow ${project.version} outside dependency management --&gt;
+ *         &lt;!-- allow property references such as ${project.version} as versions outside dependency management --&gt;
  *         &lt;allowUnmanagedProjectVersions&gt;true&lt;/allowUnmanagedProjectVersions&gt;
+ *         &lt;!-- set the allowed property names for the allowUnmanagedProjectVersions option --&gt;
+ *         &lt;allowedUnmanagedProjectVersionProps&gt;some-property.version,some-other.version&lt;/allowedUnmanagedProjectVersionProps&gt;
  *         &lt;!-- all dependency exclusions must be defined in dependency managment --&gt;
  *         &lt;manageExclusions&gt;true&lt;/manageExclusions&gt;
  *       &lt;/dependencyConfiguration&gt;
@@ -47,17 +53,34 @@ public class PedanticDependencyConfigurationEnforcer extends AbstractPedanticEnf
   /**
    * If enabled, dependency versions have to be declared in <code>&lt;dependencyManagement&gt;</code>.
    */
-  private boolean manageVersions = true;
+  private boolean manageVersions;
 
   /**
-   * Allow <code>${project.version}</code> or <code>${version}</code> as dependency version.
+   * Allow property references such as <code>${project.version}</code> or <code>${version}</code> as dependency version.
    */
-  private boolean allowUnmangedProjectVersions = true;
+  private boolean allowUnmanagedProjectVersions;
+
+  /**
+   * Controls the allowed property references for the allowUnmanagedProjectVersions option.
+   */
+  private final Set<String> allowedUnmanagedProjectVersionProps;
+
+  /**
+   * A sane default set of allowed property references for the allowUnmanagedProjectVersions option.
+   */
+  private static final Set<String> DEFAULT_ALLOWED_PROPS = new HashSet<>(Arrays.asList("${version}", "${project.version}"));
 
   /**
    * If enabled, dependency exclusions have to be declared in <code>&lt;dependencyManagement&gt;</code>.
    */
-  private boolean manageExclusions = true;
+  private boolean manageExclusions;
+
+  public PedanticDependencyConfigurationEnforcer() {
+    this.manageVersions = true;
+    this.allowUnmanagedProjectVersions = true;
+    this.allowedUnmanagedProjectVersionProps = new HashSet<>(DEFAULT_ALLOWED_PROPS);
+    this.manageExclusions = true;
+  }
 
   /**
    * If set to <code>true</code>, all dependency versions have to be defined in the dependency management.
@@ -75,13 +98,30 @@ public class PedanticDependencyConfigurationEnforcer extends AbstractPedanticEnf
    * If set to <code>true</code>, <code><version>${project.version}</version></code> may be used within
    * the dependencies section.
    *
-   * @param allowUnmangedProjectVersions Allow project versions outside of the dependencies section.
+   * @param allowUnmanagedProjectVersions Allow project versions outside of the dependencies section.
    * @configParam
    * @default <code>true</code>
    * @since 1.0.0
    */
-  public void setAllowUnmanagedProjectVersions(boolean allowUnmangedProjectVersions) {
-    this.allowUnmangedProjectVersions = allowUnmangedProjectVersions;
+  public void setAllowUnmanagedProjectVersions(boolean allowUnmanagedProjectVersions) {
+    this.allowUnmanagedProjectVersions = allowUnmanagedProjectVersions;
+  }
+
+  /**
+   * Comma-separated list of Maven property variable names (without the ${...} decorators) which are allowed to be used
+   * as version references outside dependency management. Has no effect if <code>allowUnmanagedProjectVersions</code>
+   * is set to <code>false</code>.
+   *
+   * @param allowedUnmanagedProjectVersionProps Set allowed property references for allowUnmanagedProjectVersions option.
+   * @configParam
+   * @default <code>version,project-version</code>
+   * @since 2.2.0
+   */
+  public void setAllowedUnmanagedProjectVersionProps(String allowedUnmanagedProjectVersionProps) {
+    CommaSeparatorUtils.splitAndAddToCollection(
+            allowedUnmanagedProjectVersionProps,
+            this.allowedUnmanagedProjectVersionProps,
+            prop -> String.format("${%s}", prop));
   }
 
   /**
@@ -111,17 +151,20 @@ public class PedanticDependencyConfigurationEnforcer extends AbstractPedanticEnf
     if (this.manageVersions) {
       enforceManagedVersions(report);
     }
+
     if (this.manageExclusions) {
       enforceManagedExclusion(report);
     }
   }
 
   private void enforceManagedVersions(ErrorReport report) {
-    Collection<DependencyModel> versionedDependencies = searchForDependencies(DependencyPredicate.WITH_VERSION);
+    Collection<DependencyModel> versionedDependencies = searchForDependencies(dep -> dep.getVersion() != null);
 
     // Filter all project versions if allowed
-    if (this.allowUnmangedProjectVersions) {
-      versionedDependencies = versionedDependencies.stream().filter(DependencyPredicate.WITH_PROJECT_VERSION).collect(Collectors.toList());
+    if (this.allowUnmanagedProjectVersions) {
+      versionedDependencies = versionedDependencies.stream()
+              .filter(dep -> !allowedUnmanagedProjectVersionProps.contains(dep.getVersion()))
+              .collect(Collectors.toList());
     }
 
     if (!versionedDependencies.isEmpty()) {
@@ -131,7 +174,7 @@ public class PedanticDependencyConfigurationEnforcer extends AbstractPedanticEnf
   }
 
   private void enforceManagedExclusion(ErrorReport report) {
-    Collection<DependencyModel> depsWithExclusions = searchForDependencies(DependencyPredicate.WITH_EXCLUSION);
+    Collection<DependencyModel> depsWithExclusions = searchForDependencies(dep -> !dep.getExclusions().isEmpty());
 
     if (!depsWithExclusions.isEmpty()) {
       report.addLine("Dependency exclusions have to be declared in <dependencyManagement>:")
@@ -142,27 +185,5 @@ public class PedanticDependencyConfigurationEnforcer extends AbstractPedanticEnf
   private Collection<DependencyModel> searchForDependencies(Predicate<DependencyModel> predicate) {
     List<DependencyModel> dependencies = getProjectModel().getDependencies();
     return dependencies.stream().filter(predicate).collect(Collectors.toList());
-  }
-
-  private enum DependencyPredicate implements Predicate<DependencyModel> {
-    WITH_VERSION {
-      @Override
-      public boolean test(DependencyModel input) {
-        return input.getVersion() != null;
-      }
-    },
-    WITH_PROJECT_VERSION {
-      @Override
-      public boolean test(DependencyModel input) {
-        return !"${project.version}".equals(input.getVersion())
-            && !"${version}".equals(input.getVersion());
-      }
-    },
-    WITH_EXCLUSION {
-      @Override
-      public boolean test(DependencyModel input) {
-        return !input.getExclusions().isEmpty();
-      }
-    }
   }
 }

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticDependencyConfigurationEnforcerTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticDependencyConfigurationEnforcerTest.java
@@ -115,6 +115,69 @@ public class PedanticDependencyConfigurationEnforcerTest extends AbstractPedanti
     executeRuleAndCheckReport(false);
   }
 
+  @Test
+  public void allowedVersionWithProps() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    this.projectModel.getDependencies().add(createDependency(false, false));
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void allowedVersionWithDisabledProps1() {
+    this.testRule.setManageVersions(false);
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    this.projectModel.getDependencies().add(createDependency(true, false));
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void allowedVersionWithDisabledProps2() {
+    this.testRule.setAllowUnmanagedProjectVersions(false);
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    this.projectModel.getDependencies().add(createDependency(false, false));
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void forbiddenVersionWithCustomProps1() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    this.projectModel.getDependencies().add(createDependency(true, false));
+
+    executeRuleAndCheckReport(true);
+  }
+
+  @Test
+  public void forbiddenVersionWithCustomProps2() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    DependencyModel dependency = createDependency(true, false);
+    when(dependency.getVersion()).thenReturn("${project.version}");
+    this.projectModel.getDependencies().add(dependency);
+
+    executeRuleAndCheckReport(true);
+  }
+
+  @Test
+  public void allowedVersionWithActiveCustomProps1() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    DependencyModel dependency = createDependency(true, false);
+    when(dependency.getVersion()).thenReturn("${some.version}");
+    this.projectModel.getDependencies().add(dependency);
+
+    executeRuleAndCheckReport(false);
+  }
+  @Test
+  public void allowedVersionWithActiveCustomProps2() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version,some.other.version");
+    DependencyModel dependency = createDependency(true, false);
+    when(dependency.getVersion()).thenReturn("${some.other.version}");
+    this.projectModel.getDependencies().add(dependency);
+
+    executeRuleAndCheckReport(false);
+  }
+
   private DependencyModel createDependency(boolean withVersion, boolean withExclusion) {
     DependencyModel dependency = mock(DependencyModel.class);
 

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticPluginConfigurationEnforcerTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticPluginConfigurationEnforcerTest.java
@@ -131,6 +131,66 @@ public class PedanticPluginConfigurationEnforcerTest extends AbstractPedanticEnf
     executeRuleAndCheckReport(true);
   }
 
+  @Test
+  public void allowedVersionWithProps() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    addPlugin(false, false, false);
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void allowedVersionWithDisabledProps1() {
+    this.testRule.setManageVersions(false);
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    addPlugin(true, false, false);
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void allowedVersionWithDisabledProps2() {
+    this.testRule.setAllowUnmanagedProjectVersions(false);
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    addPlugin(false, false, false);
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void forbiddenVersionWithCustomProps1() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    addPlugin(true, false, false);
+
+    executeRuleAndCheckReport(true);
+  }
+
+  @Test
+  public void forbiddenVersionWithCustomProps2() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    PluginModel plugin = addPlugin(true, false, false);
+    when(plugin.getVersion()).thenReturn("${project.version}");
+
+    executeRuleAndCheckReport(true);
+  }
+
+  @Test
+  public void allowedVersionWithActiveCustomProps1() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version");
+    PluginModel plugin = addPlugin(true, false, false);
+    when(plugin.getVersion()).thenReturn("${some.version}");
+
+    executeRuleAndCheckReport(false);
+  }
+  @Test
+  public void allowedVersionWithActiveCustomProps2() {
+    this.testRule.setAllowedUnmanagedProjectVersionProps("some.version,some.other.version");
+    PluginModel plugin = addPlugin(true, false, false);
+    when(plugin.getVersion()).thenReturn("${some.other.version}");
+
+    executeRuleAndCheckReport(false);
+  }
+
   private PluginModel addPlugin(boolean withVersion, boolean withConfiguration, boolean withDependencies) {
     PluginModel plugin = mock(PluginModel.class);
 

--- a/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticPluginConfigurationEnforcerTest.java
+++ b/src/test/java/com/github/ferstl/maven/pomenforcers/PedanticPluginConfigurationEnforcerTest.java
@@ -105,7 +105,33 @@ public class PedanticPluginConfigurationEnforcerTest extends AbstractPedanticEnf
     executeRuleAndCheckReport(true);
   }
 
-  private void addPlugin(boolean withVersion, boolean withConfiguration, boolean withDependencies) {
+  @Test
+  public void allowedProjectVersion1() {
+    this.testRule.setAllowUnmanagedProjectVersions(true);
+    PluginModel plugin = addPlugin(false, false, false);
+    when(plugin.getVersion()).thenReturn("${project.version}");
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void allowedProjectVersion2() {
+    PluginModel plugin = addPlugin(false, false, false);
+    when(plugin.getVersion()).thenReturn("${version}");
+
+    executeRuleAndCheckReport(false);
+  }
+
+  @Test
+  public void forbiddenProjectVersion() {
+    this.testRule.setAllowUnmanagedProjectVersions(false);
+    PluginModel plugin = addPlugin(false, false, false);
+    when(plugin.getVersion()).thenReturn("${project.version}");
+
+    executeRuleAndCheckReport(true);
+  }
+
+  private PluginModel addPlugin(boolean withVersion, boolean withConfiguration, boolean withDependencies) {
     PluginModel plugin = mock(PluginModel.class);
 
     when(plugin.getGroupId()).thenReturn("a.b.c");
@@ -125,5 +151,6 @@ public class PedanticPluginConfigurationEnforcerTest extends AbstractPedanticEnf
     }
 
     this.testRule.getProjectModel().getPlugins().add(plugin);
+    return plugin;
   }
 }

--- a/src/test/projects/example-project/pom.xml
+++ b/src/test/projects/example-project/pom.xml
@@ -127,7 +127,8 @@
                 <!-- Dependency Configuration -->
                 <manageDependencyVersions>true</manageDependencyVersions>
                 <manageDependencyExclusions>true</manageDependencyExclusions>
-                <allowUnmangedProjectVersions>true</allowUnmangedProjectVersions>
+                <allowDependencyUnmanagedProjectVersions>true</allowDependencyUnmanagedProjectVersions>
+                <allowedDependencyUnmanagedProjectVersionProps>version,project.version</allowedDependencyUnmanagedProjectVersionProps>
 
                 <!-- Dependency Elements -->
                 <checkDependencyElements>true</checkDependencyElements>
@@ -157,6 +158,8 @@
                 <!-- Plugin configuration -->
                 <managePluginVersions>true</managePluginVersions>
                 <managePluginConfigurations>true</managePluginConfigurations>
+                <allowPluginUnmanagedProjectVersions>true</allowPluginUnmanagedProjectVersions>
+                <allowedPluginUnmanagedProjectVersionProps>version,project.version</allowedPluginUnmanagedProjectVersionProps>
 
                 <!-- Plugin elements -->
                 <checkPluginElements>true</checkPluginElements>


### PR DESCRIPTION
Continuation of https://github.com/ferstl/pedantic-pom-enforcers/pull/44 
This is more customizable for end-users (like me :))

So the idea is basically https://github.com/ferstl/pedantic-pom-enforcers/issues/43 , but with the addition that the allowed version params/vars are no longer just `${version}` and `${project.version}`, but are customizable. The previous vars are now just defaults which can be overridden.

The use case would be some giant multi-module projects which have dependencies on other giant multi-module projects.
Untangling that kind of spaghetti in 1 go is a nightmare, so we have to do it gradually.
Using properties to set versions is a big help in that case, even when strict dependency-management would be even better.